### PR TITLE
Open source19.9 (Removed keys from config/env)

### DIFF
--- a/src/components/settings/settings-tabs/SettingsTabs.jsx
+++ b/src/components/settings/settings-tabs/SettingsTabs.jsx
@@ -23,13 +23,6 @@ export default ({ activeKey, projectID }) => {
             }}
           />
         </TabPane>
-        <TabPane tab='License' key='license'>
-          <Redirect
-            to={{
-              pathname: `/mission-control/projects/${projectID}/${projectModules.SETTINGS}/license`
-            }}
-          />
-        </TabPane>
       </Tabs>
     </div>
   )

--- a/src/components/sidenav/Sidenav.jsx
+++ b/src/components/sidenav/Sidenav.jsx
@@ -102,9 +102,6 @@ const Sidenav = (props) => {
           <Link to={`/mission-control/projects/${projectID}/${projectModules.USER_MANAGEMENT}`} onClick={closeSidenav}>
             <SidenavItem name="Auth" icon="how_to_reg" active={props.selectedItem === projectModules.USER_MANAGEMENT} />
           </Link>
-          <Link to={`/mission-control/projects/${projectID}/${projectModules.INTEGRATIONS}`} onClick={closeSidenav}>
-            <SidenavItem name="Integrations" icon="extension" active={props.selectedItem === projectModules.INTEGRATIONS} />
-          </Link>
           <Link to={`/mission-control/projects/${projectID}/${projectModules.EXPLORER}`} onClick={closeSidenav}>
             <SidenavItem name="API Explorer" icon="explore" active={props.selectedItem === projectModules.EXPLORER} />
           </Link>

--- a/src/components/sidenav/Sidenav.jsx
+++ b/src/components/sidenav/Sidenav.jsx
@@ -34,23 +34,11 @@ const PanelItem = (props) => {
     </div>
   )
 }
-const getPlanName = (planId) => {
-  if (!planId) return "Opensource"
-  // Strip the monthly/yearly and inr details from the plan id
-  const temp = planId.split("--")[0]
-  // Remove the space-cloud- prefix
-  let plan = temp.replace("space-cloud-", "")
-  if (plan === "open") plan = "opensource"
-  // Make first letter of each word capital. eg my-custom -> My Custom
-  const planName = plan.split("-").map(s => capitalizeFirstCharacter(s)).join(" ")
-  return planName
-}
 const Sidenav = (props) => {
   const { projectID } = useParams()
   const showSidenav = useSelector(state => state.uiState.showSidenav)
   const sideNavActiveKeys = useSelector(state => state.uiState.sideNavActiveKeys)
-  const { plan, version } = useSelector(state => getEnv(state))
-  const planName = getPlanName(plan)
+  const { version } = useSelector(state => getEnv(state))
   const closeSidenav = () => {
     store.dispatch(set("uiState.showSidenav", false))
   }
@@ -116,7 +104,6 @@ const Sidenav = (props) => {
             <Space direction="vertical" size={4}>
               <Typography.Text>SC Version - v{version}</Typography.Text>
               <Typography.Text>UI Version - v{uiVersion}</Typography.Text>
-              <Typography.Text type="secondary">{planName}</Typography.Text>
             </Space>
           </div>
         </div>

--- a/src/mirage/server.js
+++ b/src/mirage/server.js
@@ -38,7 +38,7 @@ export function makeServer({ environment = "development" } = {}) {
       this.timing = 500;
 
       // Global endpoints
-      this.get("/config/env", () => ({ isProd: false, loginURL: "/mission-control/login", version: "0.19.0", clusterName: "Cluster 1", plan: "space-cloud-pro--monthly-inr", licenseKey: "lic_21kj9kms8msls9", licenseMode: "offline", sessionId: "fb2e77d.47a0479900504cb3ab4a1f626d174d2djimHalpert1", nextRenewal: "2020-04-19T08:45:57Z", quotas: { maxDatabases: 4, maxProjects: 3, integrationLevel: 2 } }));
+      this.get("/config/env", () => ({ isProd: false, loginURL: "/mission-control/login", version: "0.19.0" }));
       this.get("/config/permissions", () => respondOk({ result: fixtures.permissions }));
       this.post("/config/login", () => respondOk({ token: "eyJhbGciOiJIUzI1NiJ9.ewogICJpZCI6ICIxIiwKICAicm9sZSI6ICJ1c2VyIiwKICAiZW1haWwiOiAidGVzdEBnbWFpbC5jb20iLAogICJuYW1lIjogIlRlc3QgdXNlciIKfQ.xzmkfIr_eDwgIBIgOP-eVpyACgtA8TeE03BMpx-WdQ0" }));
       this.get("/config/refresh-token", () => respondOk({ token: "eyJhbGciOiJIUzI1NiJ9.ewogICJpZCI6ICIxIiwKICAicm9sZSI6ICJ1c2VyIiwKICAiZW1haWwiOiAidGVzdEBnbWFpbC5jb20iLAogICJuYW1lIjogIlRlc3QgdXNlciIKfQ.xzmkfIr_eDwgIBIgOP-eVpyACgtA8TeE03BMpx-WdQ0" }));

--- a/src/routes/ProjectPages.jsx
+++ b/src/routes/ProjectPages.jsx
@@ -39,19 +39,11 @@ import Graphql from "../pages/explorer/graphql/Graphql";
 import SpaceApi from "../pages/explorer/spaceApi/SpaceApi";
 import ProjectSettings from "../pages/settings/project/ProjectSettings";
 import ClusterSettings from "../pages/settings/cluster/ClusterSettings";
-import LicenseSettings from "../pages/settings/license/LicenseSettings";
-import ApplyLicense from "../pages/settings/apply-license/ApplyLicense";
 import RoutingOverview from '../pages/routing/overview/Overview';
 import RoutingSettings from '../pages/routing/settings/Settings';
 import SecretsIndex from "../pages/secrets/Index";
 import Secrets from '../pages/secrets/Secrets';
 import SecretDetails from '../pages/secrets/SecretDetails';
-import IntegrationsIndex from '../pages/integrations/Index';
-import ExploreIntegrations from '../pages/integrations/ExploreIntegrations';
-import InstalledIntegrations from '../pages/integrations/InstalledIntegrations';
-import InstallIntegration from '../pages/integrations/InstallIntegration';
-import IntegrationDetails from '../pages/integrations/IntegrationDetails';
-import IntegrationPermissions from '../pages/integrations/IntegrationPermissions';
 
 
 function ProjectPages() {
@@ -81,8 +73,6 @@ function ProjectPages() {
         component={props => <Redirect to={`/mission-control/projects/${props.match.params.projectID}/settings/project`} />} />
       <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.SETTINGS}/project`} component={ProjectSettings} />
       <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.SETTINGS}/cluster`} component={ClusterSettings} />
-      <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.SETTINGS}/license`} component={LicenseSettings} />
-      <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.SETTINGS}/apply-license`} component={ApplyLicense} />
       <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.INGRESS_ROUTES}`}
         component={props => <Redirect to={`/mission-control/projects/${props.match.params.projectID}/${projectModules.INGRESS_ROUTES}/overview`} />} />
       <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.INGRESS_ROUTES}/overview`} component={RoutingOverview} />
@@ -115,14 +105,6 @@ function ProjectPages() {
       <PrivateRoute path={`/mission-control/projects/:projectID/${projectModules.SECRETS}`} component={SecretsIndex} />
       <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.SECRETS}`} component={Secrets} />
       <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.SECRETS}/:secretId`} component={SecretDetails} />
-      <PrivateRoute path={`/mission-control/projects/:projectID/${projectModules.INTEGRATIONS}`} component={IntegrationsIndex} />
-      <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.INTEGRATIONS}`}
-        component={props => <Redirect to={`/mission-control/projects/${props.match.params.projectID}/${projectModules.INTEGRATIONS}/explore`} />} />
-      <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.INTEGRATIONS}/explore`} component={ExploreIntegrations} />
-      <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.INTEGRATIONS}/installed`} component={InstalledIntegrations} />
-      <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.INTEGRATIONS}/details/:integrationId`} component={IntegrationDetails} />
-      <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.INTEGRATIONS}/install/:integrationId`} component={InstallIntegration} />
-      <PrivateRoute exact path={`/mission-control/projects/:projectID/${projectModules.INTEGRATIONS}/permissions/:integrationId`} component={IntegrationPermissions} />
     </React.Fragment>
   )
 }

--- a/src/store.js
+++ b/src/store.js
@@ -42,10 +42,7 @@ const initialState = {
 	},
 	eventLogs: [],
 	env: {
-		version: "",
-		clusterId: null,
-		plan: "space-cloud-open--monthly",
-		quotas: { maxDatabases: 1, maxProjects: 1, integrationLevel: 0 }
+		version: ""
 	}
 };
 


### PR DESCRIPTION
- Out of the removed keys, only `plan` was used in `<Sidenav />` component.
- Components such as `<LicenseDetails />` and `<LicenseSettings />` are defunct.